### PR TITLE
chore: update workflow backend

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-      - run: ./mvnw clean package -DskipTests=false
-      - run: ./mvnw test
+      - run: mvn clean package -DskipTests=false
+      - run: mvn test
 
 # Para deploy automático a Render, Railway, Fly.io, puedes usar webhooks o su CLI en otro job. 


### PR DESCRIPTION
This pull request updates the `.github/workflows/backend.yml` file to improve the build process by replacing the use of the Maven wrapper (`./mvnw`) with the system-installed `mvn` command. 

Build process updates:

* Replaced `./mvnw` with `mvn` for the `clean package` and `test` commands to use the system-installed Maven instead of the Maven wrapper. (`[.github/workflows/backend.ymlL23-R24](diffhunk://#diff-4221e7060cb5692b5e8656f8f092468895f4bc8804397e8de7cb4cfdf8d95024L23-R24)`)