### PR TITLE
docs: add public deployment and multi-stage Docker instructions to RE…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,130 +6,36 @@ Este proyecto resuelve el desafío de cargar tiempos de viaje entre ubicaciones 
 
 ---
 
+## Despliegue público gratuito (Render, Vercel, Netlify)
+
+### Backend (Java Spring Boot)
+- **Render.com** (recomendado):
+  - El Dockerfile usa multi-stage build, por lo que Render puede construir y ejecutar el backend sin requerir el JAR precompilado.
+  - Solo sube tu repo y Render ejecutará el Dockerfile correctamente.
+  - No necesitas la carpeta `target/` en el repo.
+- **Railway/Fly.io:**
+  - También soportan Docker multi-stage build.
+
+### Frontend (Vue)
+- **Vercel o Netlify** (recomendado):
+  - Sube el contenido de `frontend/` a un repo en GitHub.
+  - Conecta el repo desde el dashboard de Vercel/Netlify.
+  - Build command: `npm run build`  
+    Output dir: `dist`
+  - Obtendrás una URL pública para tu frontend.
+- **GitHub Pages:**
+  - Solo para sitios estáticos. Si usas history mode, configura el rewrite a `index.html`.
+
+### Tips de configuración para despliegue público
+- **CORS:**
+  - Asegúrate de que el backend permita el origen del frontend público (por ejemplo, `https://tufrontend.vercel.app`).
+- **Endpoints:**
+  - En producción, configura el frontend para apuntar a la URL pública del backend.
+- **Variables de entorno:**
+  - Usa variables de entorno en Vercel/Netlify/Render para configurar endpoints y secrets.
+
+---
+
 ## Estructura del Proyecto
 
 ```
-Octadot-test/
-├── backend/        # Backend Java Spring Boot
-├── frontend/       # Frontend Vue 3 + Vite
-├── docker-compose.yml
-├── README.md       # Este archivo
-```
-
----
-
-## Requisitos
-- Docker y Docker Compose
-- (Opcional) Java 21+ y Maven para desarrollo local backend
-- (Opcional) Node.js 20+ y npm para desarrollo local frontend
-
----
-
-## Levantar TODO con Docker Compose
-
-1. Desde la raíz del proyecto:
-   ```bash
-   docker-compose up --build -d
-   ```
-2. Accede a:
-   - **Frontend:** [http://localhost:8081](http://localhost:8081)
-   - **Backend:** [http://localhost:8080](http://localhost:8080)
-3. Para detener:
-   ```bash
-   docker-compose down
-   ```
-
----
-
-## Levantar solo un servicio
-- **Backend:**
-  ```bash
-  docker-compose up --build -d backend
-  ```
-- **Frontend:**
-  ```bash
-  docker-compose up --build -d frontend
-  ```
-
----
-
-## Desarrollo local (opcional)
-- **Backend:**
-  ```bash
-  cd backend
-  mvn spring-boot:run
-  # http://localhost:8080
-  ```
-- **Frontend:**
-  ```bash
-  cd frontend
-  npm install
-  npm run dev
-  # http://localhost:5173
-  ```
-
----
-
-## Formato del CSV
-
-Archivo separado por punto y coma (`;`):
-```
-origen;destino;tiempo
-A;B;10
-B;C;15
-C;D;20
-```
-
----
-
-## Endpoints principales
-
-### Cargar conexiones (CSV)
-- **POST** `/api/connections/upload`
-- Formato: `multipart/form-data` con campo `file`
-
-### Calcular ruta más corta
-- **GET** `/api/routes/shortest?from=ORIGEN&to=DESTINO`
-- Respuesta:
-  ```json
-  { "route": ["A", "B", "C"], "totalTime": 25 }
-  ```
-
-### Listar conexiones
-- **GET** `/api/connections/list`
-
----
-
-## Pruebas y troubleshooting
-
-- Si tienes errores de CORS, asegúrate de que el backend permite los orígenes `http://localhost:8081` y `http://localhost:5173`.
-- Si tienes error 405 o 500, revisa los logs del backend y frontend:
-  ```bash
-  docker-compose logs backend
-  docker-compose logs frontend
-  ```
-- Si cambias código, ejecuta:
-  ```bash
-  mvn clean package -DskipTests
-  docker-compose build backend
-  docker-compose restart backend
-  ```
-
----
-
-## Testing
-- El backend incluye pruebas unitarias y de integración (ver carpeta `backend/src/test`).
-- Para correr tests backend:
-  ```bash
-  cd backend
-  mvn test
-  ```
-
----
-
-## Notas finales
-- El sistema está listo para producción o pruebas locales.
-- Puedes extender la solución para autenticación JWT, multiempresa real, o persistencia en base de datos.
-- Para dudas o mejoras, revisa los README de cada subcarpeta.
-
----

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,12 @@
+# Stage 1: Build
+FROM maven:3.9.6-eclipse-temurin-21 AS build
+WORKDIR /app
+COPY . .
+RUN mvn clean package -DskipTests
+
+# Stage 2: Run
 FROM eclipse-temurin:21-jdk-alpine
 WORKDIR /app
-COPY target/*.jar app.jar
-COPY firebase-service-account.json .
-ENV FIREBASE_CONFIG_PATH=/app/firebase-service-account.json
+COPY --from=build /app/target/*.jar app.jar
+EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -12,6 +12,22 @@ Backend Java Spring Boot para cargar tiempos de viaje entre ubicaciones desde un
 
 ---
 
+## Build multi-stage para despliegue en Render, Railway, Fly.io
+
+El Dockerfile usa un **multi-stage build**: construye el JAR dentro del contenedor usando Maven y luego lo ejecuta en una imagen ligera. No necesitas compilar el JAR antes de hacer el build de la imagen.
+
+### Ejemplo de build local
+```bash
+docker build -t ruta-backend .
+docker run -p 8080:8080 ruta-backend
+```
+
+### Despliegue en Render
+- Solo sube tu repo y Render ejecutará el Dockerfile correctamente.
+- No necesitas el JAR precompilado ni la carpeta `target/` en el repo.
+
+---
+
 ## Levantar solo el backend con Docker Compose
 
 Desde la raíz del proyecto o desde la carpeta backend:


### PR DESCRIPTION
This pull request focuses on transitioning the project to use modern deployment strategies with public cloud platforms and improving the backend's Docker configuration. The most significant changes include replacing local Docker Compose instructions with deployment instructions for services like Render, Vercel, and Netlify, and introducing a multi-stage Docker build for the backend.

### Deployment updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-L135): Replaced local Docker Compose instructions with detailed steps for deploying the backend and frontend to platforms like Render, Vercel, and Netlify. Added tips for handling CORS, configuring endpoints, and using environment variables for production setups.

### Backend Docker improvements:
* [`backend/Dockerfile`](diffhunk://#diff-fed51f49a9f26cb93cc870efdc9419d425b9422354ae41bb651c3333c8bff486R1-R11): Introduced a multi-stage Docker build. The first stage builds the JAR file using Maven, and the second stage runs the application in a lightweight image, eliminating the need for precompiled artifacts in the repo.
* [`backend/README.md`](diffhunk://#diff-a54d2dad1be5eea9e70f8514ae65d89b65357120a312bfb9f644ddeb1844ca0dR15-R30): Added instructions for building and deploying the backend using the new multi-stage Dockerfile, including local build examples and deployment notes for Render.