### PR TITLE
docs(frontend): add production API URL instructions for Vercel/Netlif…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,12 +130,6 @@ node_modules/
 # Yarn Integrity file
 .yarn-integrity
 
-# dotenv environment variables file
-.env
-.env.test
-.env.local
-.env.production
-
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 .parcel-cache

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+VITE_API_URL=https://octadot-test.onrender.com/api

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -60,3 +60,15 @@ npm run dev
   ```
 
 ---
+
+## Despliegue en producción (Vercel, Netlify, etc)
+
+Para que el frontend se comunique con el backend público, crea un archivo `.env.production` en la carpeta `frontend/` con el siguiente contenido:
+
+```
+VITE_API_URL=https://octadot-test.onrender.com/api
+```
+
+Esto hará que el build de producción use la URL pública del backend desplegado en Render. Si cambias la URL del backend, actualiza este valor.
+
+---

--- a/frontend/src/components/FileUploadPanel.vue
+++ b/frontend/src/components/FileUploadPanel.vue
@@ -85,7 +85,8 @@ async function onUpload() {
   try {
     const formData = new FormData()
     formData.append('file', file.value)
-    await axios.post('/api/connections/upload', formData)
+    const apiUrl = import.meta.env.VITE_API_URL || '/api';
+    await axios.post(`${apiUrl}/connections/upload`, formData)
     success.value = true
     emit('uploaded')
   } catch (err) {


### PR DESCRIPTION
This pull request introduces changes to enable the frontend to communicate with a deployed backend in production environments. The key updates include adding a production environment variable for the API URL, updating the documentation to guide developers on configuring this variable, and modifying the file upload logic to use the environment-specific API URL.

### Environment Configuration for Production:

* [`frontend/.env.production`](diffhunk://#diff-43d23032c06237e0fb7a9416cd2e5fbe223fe2260c7f1aafa0e5bf58f0e30918R1): Added a new environment variable `VITE_API_URL` pointing to the public backend URL (`https://octadot-test.onrender.com/api`).

### Documentation Updates:

* [`frontend/README.md`](diffhunk://#diff-35aa98d245b201cfc92c74313abcf8fa0f6069fc750f05e7a755665360a0e543R63-R74): Added a section explaining how to configure the `.env.production` file with the `VITE_API_URL` variable to ensure the frontend communicates with the correct backend in production.

### Code Updates for API URL:

* [`frontend/src/components/FileUploadPanel.vue`](diffhunk://#diff-cf912ba74cdf99197e02bf7a89de70255e7b39f22ed1b39b185f44dcfd61b654L88-R89): Updated the `onUpload` function to dynamically use the `VITE_API_URL` environment variable if available, defaulting to `/api` otherwise. This ensures compatibility with both local and production environments.