### PR TITLE
fix(cors): allow Vercel production domain in backend CORS config

### DIFF
--- a/backend/src/main/java/com/ruta/api/config/CorsConfig.java
+++ b/backend/src/main/java/com/ruta/api/config/CorsConfig.java
@@ -13,7 +13,11 @@ public class CorsConfig {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/api/**")
-                        .allowedOrigins("http://localhost:8081", "http://localhost:5173")
+                        .allowedOrigins(
+                            "http://localhost:8081",
+                            "http://localhost:5173",
+                            "https://octadot-test.vercel.app"
+                        )
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                         .allowedHeaders("*");
             }


### PR DESCRIPTION
This pull request updates the CORS configuration in the `CorsConfig` class to allow an additional origin for API access.

* [`backend/src/main/java/com/ruta/api/config/CorsConfig.java`](diffhunk://#diff-48ab64c3495f350cc4ac3aa30f218bd57e3586ca6651e00ffeb2d9517f94f81eL16-R20): Added `https://octadot-test.vercel.app` to the list of allowed origins in the `addCorsMappings` method.