### PR TITLE
git commit -m "fix: use VITE_API_URL in all frontend API requests

### DIFF
--- a/frontend/src/components/RouteCalculatorPanel.vue
+++ b/frontend/src/components/RouteCalculatorPanel.vue
@@ -52,7 +52,8 @@ onMounted(() => {
 async function fetchLocations() {
   // Obtenemos las ubicaciones desde el endpoint de conexiones
   try {
-    const res = await axios.get('/api/connections/list')
+    const apiUrl = import.meta.env.VITE_API_URL || '/api';
+    const res = await axios.get(`${apiUrl}/connections/list`)
     // Extraer ubicaciones del texto de respuesta
     const match = res.data.match(/\[(.*?)\]/)
     if (match && match[1]) {
@@ -70,7 +71,8 @@ async function onCalculate() {
   if (!from.value || !to.value) return
   loading.value = true
   try {
-    const res = await axios.get('/api/routes/shortest', {
+    const apiUrl = import.meta.env.VITE_API_URL || '/api';
+    const res = await axios.get(`${apiUrl}/routes/shortest`, {
       params: { from: from.value, to: to.value }
     })
     route.value = res.data.route


### PR DESCRIPTION
This pull request updates the API URL handling in `RouteCalculatorPanel.vue` to use an environment variable (`VITE_API_URL`) if available, improving flexibility and configurability for different deployment environments.

### API URL Handling Updates:

* Updated the `fetchLocations` function to dynamically construct the API URL using `import.meta.env.VITE_API_URL` with a fallback to `/api`. This ensures the application can adapt to different API base URLs without hardcoding.
* Updated the `onCalculate` function to use the same dynamic API URL construction for fetching the shortest route, maintaining consistency across API calls.